### PR TITLE
Separating settings from code

### DIFF
--- a/server.py
+++ b/server.py
@@ -7,21 +7,8 @@ import os
 import os.path
 import urlparse
 
-# Various config settings for the python server
-SETTINGS = {
-    'port':        8080,
-    'logging':     False,
-
-    'api-save':    '/lib/weltmeister/api/save.php',
-    'api-browse':  '/lib/weltmeister/api/browse.php',
-    'api-glob':    '/lib/weltmeister/api/glob.php',
-
-    'image-types': ['.png', '.jpg', '.gif', '.jpeg'],
-
-    'mimetypes': {
-        'ogg': 'audio/ogg'
-    }
-}
+# Settings comes from the settings.py file
+from settings import SETTINGS
 
 # Override port if we are on a Heroku server
 if os.environ.get('PORT'):

--- a/settings.py
+++ b/settings.py
@@ -1,0 +1,15 @@
+# Various config settings for the python server
+SETTINGS = {
+    'port':        8080,
+    'logging':     False,
+
+    'api-save':    '/lib/weltmeister/api/save.php',
+    'api-browse':  '/lib/weltmeister/api/browse.php',
+    'api-glob':    '/lib/weltmeister/api/glob.php',
+
+    'image-types': ['.png', '.jpg', '.gif', '.jpeg'],
+
+    'mimetypes': {
+        'ogg': 'audio/ogg'
+    }
+}


### PR DESCRIPTION
As a good practice, this pull request separates settings from the code. 

This enables to get the versioned script (by cloning or raw like in `wget https://raw.github.com/amadeus/python-impact/master/server.py -O server.py`) and override the settings.py file with what applies to the user.
